### PR TITLE
fix: Bugs in search by dropdown, datetime sort & edit in service search

### DIFF
--- a/routes/service.js
+++ b/routes/service.js
@@ -219,8 +219,6 @@ function formatSearchSelect(response) {
     aaData: response.rows,
   };
   (records.aaData).forEach(function (record) {
-    record['일자'] = moment(record['일자']).format('MM/DD/YYYY a h:mm');
-    record['기한'] = moment(record['기한']).format('MM/DD/YYYY a h:mm');
     let address = record['주소'].split('/');
     record['지번 주소'] = address[0] ? address[0].trim() : '';
     let addr_desc = address[2] ? address[2].trim() : '';

--- a/tools/webpack/webgis/javascript/service/search/EditModal.js
+++ b/tools/webpack/webgis/javascript/service/search/EditModal.js
@@ -76,7 +76,8 @@ export default class EditModal {
         if (resultObj[code] != null) {
           that[code].selectpicker('val', resultObj[code]);
         } else {
-          that[code].parent().attr('hidden', true);
+          // that[code].parent().attr('hidden', true);
+          that[code].val('').selectpicker('refresh');
         }
       });
 
@@ -111,7 +112,7 @@ export default class EditModal {
           message: '선택한 민원이 수정되었습니다',
         }, { type: 'success' });
         tableAjax.reload();
-      }, 2000);
+      }, 1500);
     }
 
     function onError(err) {

--- a/tools/webpack/webgis/views/partials/_modal/_service-edit.html
+++ b/tools/webpack/webgis/views/partials/_modal/_service-edit.html
@@ -113,7 +113,7 @@
                   </div>
                   <div class="col-lg-2">
                     <select class="form-control selectpicker" name="pip_dip" title="관경" data-size="6">
-                      <option value="" hidden></option>
+                      <option value="">없음</option>
                       <option value="16">16 mm</option>
                       <option value="20">20 mm</option>
                       <option value="25">25 mm</option>
@@ -127,7 +127,7 @@
                   </div>
                   <div class="col-lg-2">
                     <select class="form-control selectpicker" name="lep_cde" title="누수 위치" data-size="6">
-                      <option value="" hidden></option>
+                      <option value="">없음</option>
                       <option value="새들분기">새들분기점</option>
                       <option value="T분기">T 분기점</option>
                       <option value="클램프">클램프 보수</option>


### PR DESCRIPTION
접수내용(apl_cde) search filters are set from dropdown (selectpicker)
and requires different formatting for search to work properly.
And because of whitespace within some of the selected values such as
"도로 누수", the search results included invalid results such as
"보호통 누수 및 교체". To ignore whitespaces within these values
whitespaces should be replaced by . for datatables.net library to work.
See: https://datatables.net/reference/api/search()

Datetime sorting bugs were solved by having nodejs server send raw
data to the client and letting the client to the formatting instead
using momentjs library.

Fixed bug where selectpicker dropdowns did not appear upon page load