### PR TITLE
refactor: Further cut down on redundant babel configurations

### DIFF
--- a/tools/webpack/webgis/webgis.config.js
+++ b/tools/webpack/webgis/webgis.config.js
@@ -51,20 +51,6 @@ const webpackRules = {
     exclude: [/(node_modules|bower_components)/, /__tests__/],
     loader: 'babel-loader',
     options: {
-      presets: [
-        [
-          '@babel/preset-env',
-          {
-            targets: {
-              node: 'current', // !!!DO NOT REMOVE!!!
-            },
-          },
-        ],
-      ],
-      plugins: [
-        '@babel/plugin-proposal-class-properties',
-        '@babel/plugin-transform-runtime',
-      ],
       cacheDirectory: true,
       rootMode: 'upward',
     },


### PR DESCRIPTION
Use babel.config.json in the project root to setup presets and plugins