### PR TITLE
fix: Move upload directory outside of public

### DIFF
--- a/app.js
+++ b/app.js
@@ -69,9 +69,10 @@ app.use(cors({
 app.use(passport.initialize({}));
 app.use(passport.session(false));
 app.use(express.static(path.join(__dirname, 'public')));
+app.use(express.static(path.join(__dirname, 'upload')));
 
-if (!fs.existsSync(path.join(__dirname, 'public', 'uploads'))){
-  fs.mkdirSync(path.join(__dirname, 'public', 'uploads'));
+if (!fs.existsSync(path.join(__dirname, 'upload'))){
+  fs.mkdirSync(path.join(__dirname, 'upload'));
 }
 
 passportSetup(passport);

--- a/routes/data.js
+++ b/routes/data.js
@@ -10,7 +10,7 @@ const defaultFormidableOptions = {
   allowEmptyFiles: false,
   keepExtensions: false,
   multiples: true,
-  uploadDir: path.join(__dirname, 'public', 'uploads'),
+  uploadDir: path.join(__dirname, 'upload'),
 };
 
 export default {


### PR DESCRIPTION
This prevents accidental removal of user uploaded contents
when updating public static files